### PR TITLE
Set isBCM2835Initialized when initializdd

### DIFF
--- a/src/powerblock/GPIO.cpp
+++ b/src/powerblock/GPIO.cpp
@@ -35,6 +35,7 @@ GPIO::GPIO()
         {
             std::cout << "Error initializing GPIO." << std::endl;
         }
+        isBCM2835Initialized = true;
     }
 }
 


### PR DESCRIPTION
I believe you should mark when the initialization is completed.
