### PR TITLE
Make it possible to change Raspberry pins via powerblockconfig.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The parameters are explained in detail in the following:
  - ```powerswitch - activated```: Can be set to
      + ```true```: Activates the handling of the power switch signals of the PowerBlock.
      + ```false```: Deactivates the handling of the power switch signals of the PowerBlock.
+ - ```statuspin```: Raspberry BCM pin used for status signaling (default: 17) connects to S2 on PowerBlock
+ - ```shutdownpin```: Raspberry BCM pin used for shutdown signaling (default: 18) connects to S1 on Powerblock
 
 ## Shutdown Script
 

--- a/src/powerblock/PowerBlock.cpp
+++ b/src/powerblock/PowerBlock.cpp
@@ -32,7 +32,7 @@ PowerBlock::PowerBlock() :
 
     configuration->initialize();
 
-    powerSwitch = new PowerSwitch(switchMapping[configuration->getShutdownActivation()]);
+    powerSwitch = new PowerSwitch(switchMapping[configuration->getShutdownActivation()], configuration->getStatusPin(), configuration->getShutdownPin());
 }
 
 PowerBlock::~PowerBlock()

--- a/src/powerblock/PowerBlockConfiguration.cpp
+++ b/src/powerblock/PowerBlockConfiguration.cpp
@@ -25,8 +25,12 @@
 
 #include "PowerBlockConfiguration.h"
 
+#include <stdint.h>
+
 PowerBlockConfiguration::PowerBlockConfiguration() :
-        doShutdown(SHUTDOWN_ACTIVATED)
+        doShutdown(SHUTDOWN_ACTIVATED),
+        statusPin(17),
+        shutdownPin(18)
 { }
 
 PowerBlockConfiguration::~PowerBlockConfiguration()
@@ -60,6 +64,21 @@ void PowerBlockConfiguration::initialize()
             doShutdown = SHUTDOWN_DEACTIVATED;
             std::cout << "[PowerBlock] Shutdown is DEACTIVATED" << std::endl;
         }
+
+        if (root["statuspin"].isNull()) {
+            statusPin = 17;
+        } else {
+            statusPin = (uint16_t) root["statuspin"].asInt();
+        }
+
+        if (root["shutdownpin"].isNull()) {
+            shutdownPin = 18;
+        } else {
+            shutdownPin = (uint16_t) root["shutdownpin"].asInt();
+        }
+
+        std::cout << "[PowerBlock] Shutdown Pin is " << shutdownPin << std::endl;
+        std::cout << "[PowerBlock] Status Pin is " << statusPin << std::endl;
     }
     catch (int errno)
     {
@@ -71,4 +90,14 @@ void PowerBlockConfiguration::initialize()
 PowerBlockConfiguration::ShutdownType_e PowerBlockConfiguration::getShutdownActivation() const
 {
     return doShutdown;
+}
+
+uint16_t PowerBlockConfiguration::getShutdownPin() const
+{
+    return shutdownPin;
+}
+
+uint16_t PowerBlockConfiguration::getStatusPin() const
+{
+    return statusPin;
 }

--- a/src/powerblock/PowerBlockConfiguration.h
+++ b/src/powerblock/PowerBlockConfiguration.h
@@ -24,6 +24,7 @@
 #define POWERBLOCKCONFIGURATION_H
 
 #include <json/json.h>
+#include <stdint.h>
 
 class PowerBlockConfiguration
 {
@@ -38,9 +39,13 @@ public:
 
     void initialize();
     ShutdownType_e getShutdownActivation() const;
+    uint16_t getShutdownPin() const;
+    uint16_t getStatusPin() const;
 
 private:
     ShutdownType_e doShutdown;
+    uint16_t shutdownPin;
+    uint16_t statusPin;
 };
 
 #endif

--- a/src/powerblock/PowerSwitch.cpp
+++ b/src/powerblock/PowerSwitch.cpp
@@ -21,20 +21,28 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
+
 #include "PowerSwitch.h"
 #include "GPIO.h"
+#include <iostream>
 
-PowerSwitch::PowerSwitch(ShutdownActivated_e doShutdown) :
-        doShutdown(SHUTDOWN_ACTIVATED)
+PowerSwitch::PowerSwitch(ShutdownActivated_e doShutdown, uint16_t _statusPin, uint16_t _shutdownPin) :
+        doShutdown(SHUTDOWN_ACTIVATED),
+        statusPin(17),
+        shutdownPin(18)
 {
+    statusPin = _statusPin;
+    shutdownPin = _shutdownPin;
+
     if (doShutdown == SHUTDOWN_ACTIVATED)
     {
         // RPI_STATUS signal
-        GPIO::getInstance().setDirection(PIN_RPI_STATUS, GPIO::DIRECTION_OUT);
+        GPIO::getInstance().setDirection(statusPin, GPIO::DIRECTION_OUT);
 
         // RPI_SHUTDOWN signal
-        GPIO::getInstance().setDirection(PIN_RPI_SHUTDOWN, GPIO::DIRECTION_IN);
-        GPIO::getInstance().setPullupMode(PIN_RPI_SHUTDOWN, GPIO::PULLDOWN_ENABLED);
+        GPIO::getInstance().setDirection(shutdownPin, GPIO::DIRECTION_IN);
+        GPIO::getInstance().setPullupMode(shutdownPin, GPIO::PULLDOWN_ENABLED);
 
         setPowerSignal(PowerSwitch::STATE_ON);
     }
@@ -58,18 +66,19 @@ void PowerSwitch::setPowerSignal(PowerState_e state)
 {
     if (state == STATE_OFF)
     {
-        GPIO::getInstance().write(PIN_RPI_STATUS, GPIO::LEVEL_LOW);
+        GPIO::getInstance().write(statusPin, GPIO::LEVEL_LOW);
     }
     else
     {
-        GPIO::getInstance().write(PIN_RPI_STATUS, GPIO::LEVEL_HIGH);
+        GPIO::getInstance().write(statusPin, GPIO::LEVEL_HIGH);
     }
 }
 
 PowerSwitch::ShutdownSignal_e PowerSwitch::getShutdownSignal()
 {
     ShutdownSignal_e signal = SHUTDOWN_FALSE;
-    if (GPIO::getInstance().read(PIN_RPI_SHUTDOWN) == GPIO::LEVEL_LOW)
+
+    if (GPIO::getInstance().read(shutdownPin) == GPIO::LEVEL_LOW)
     {
         signal = SHUTDOWN_FALSE;
     }

--- a/src/powerblock/PowerSwitch.h
+++ b/src/powerblock/PowerSwitch.h
@@ -61,7 +61,7 @@ public:
      * Constructor
      * @param doShutdown Indicates whether the power switch should update its state (=true) or not (=false)
      */
-    explicit PowerSwitch(ShutdownActivated_e doShutdown);
+    explicit PowerSwitch(ShutdownActivated_e doShutdown, uint16_t statusPin, uint16_t shutdownPin);
 
     /**
      * Destructor
@@ -74,8 +74,8 @@ public:
     void update();
 
 private:
-    static const uint16_t PIN_RPI_STATUS = 17;     //!< BCM pin number of the status signal pin
-    static const uint16_t PIN_RPI_SHUTDOWN = 18;   //!< BCM pin number of the shutdown signal pin
+    uint16_t statusPin;     //!< BCM pin number of the status signal pin
+    uint16_t shutdownPin;   //!< BCM pin number of the shutdown signal pin
 
     ShutdownActivated_e doShutdown;  //!< State of the shutdown activation
 

--- a/supplementary/powerblockconfig.cfg
+++ b/supplementary/powerblockconfig.cfg
@@ -1,5 +1,7 @@
 {
     "powerswitch" : {
         "activated" : true
-    }
+    },
+    "statuspin": 17,
+    "shutdownpin": 18
 }


### PR DESCRIPTION
Most DACs depend on BCM pin 18, so they conflict with PowerBlock. Unfortunately they can not use any other pin.

This change allows the pins PowerBlock uses to be freely configurable, allowing to use PowerBlock in cooperation with DACs.