### PR TITLE
Add build/ dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ local.properties
 .recommenders/
 
 # End of https://www.gitignore.io/api/macos,sublimetext,jetbrains,cmake,eclipse
+
+build/


### PR DESCRIPTION
Running install.sh or following the instructions given in https://github.com/petrockblog/PowerBlock#building-and-installation is leaving an untracked build dir behind which we could hide via the .gitignore:

```
# git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build/

nothing added to commit but untracked files present (use "git add" to track)
```