### PR TITLE
Fix service script on RPi Zero 2 (And compute modules?)

### DIFF
--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -166,7 +166,7 @@ echo "Detected RPi model: $model".
 
 # Determine Raspberry Pi GPIO access chip
 # chip=4 for RPi5, chip=0 for older models
-# Note this code would break on future models (eg Rpi 6)
+# Note this code would break on future models! (eg Rpi 6)
 if $GPIO_TOOLS_AVAILABLE && echo "$model" | grep -q "Raspberry Pi 5"; then
   chip=4
 else

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -78,7 +78,9 @@ setDirectionInput() {
 # Parameter $2: output value. Can be 0 or 1
 setPinValue() {
   if $GPIO_TOOLS_AVAILABLE; then
-    gpioset $chip "$1"="$2"
+    #gpioset $chip "$1"="$2"
+    gpioset -c $chip "$1"="$2" &
+    echo "pin set high successfully" | write_log
  else
     echo "$2" > $BASE_GPIO_PATH/gpio"$1"/value
  fi
@@ -88,7 +90,8 @@ setPinValue() {
 # Parameter $1: pin number to be read from
 getPinValue() {
   if $GPIO_TOOLS_AVAILABLE; then
-    gpioget $chip "$1"
+    gpioget --numeric -c $chip "$1"
+    # gpioget $chip "$1"
   else
     cat $BASE_GPIO_PATH/gpio"$1"/value
   fi
@@ -158,13 +161,12 @@ else
   echo "GPIO tools not available. Trying sysfs method." | write_log
 fi
 
-# Check for RPi model
-model=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
-echo "Detected RPi model $model".
+model=$(cat /proc/cpuinfo | grep 'Model' | cut -d ':' -f2 | xargs)
+echo "Detected RPi model: $model".
 
 # Determine Raspberry Pi GPIO access chip
 # chip=4 for RPi5, chip=0 for older models
-if [ $GPIO_TOOLS_AVAILABLE ] && [ "$model" -gt 4 ]; then
+if $GPIO_TOOLS_AVAILABLE && echo "$model" | grep -q "Raspberry Pi 5"; then
   chip=4
 else
   chip=0

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -165,14 +165,22 @@ fi
 # cat /proc/cpuinfo can yield results such as:
 # Model           : Raspberry Pi 4 Model B Rev 1.1
 # Model           : Raspberry Pi 5 Model B Rev 1.0
-# Model           : Raspberry Pi Zero W Rev 1.1
+# Model           : Raspberry Pi Zero 2 W Rev 1.0
 # If what is immediately after "Model" is a number, we can use that as the model number.
 # If not, we assume it is a Pi 4 or below (using GPIO chip 0).
 # !! This code may need updating eg if a new Zero model is released that uses GPIO chip 4.
 model_string=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
 if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
-  echo "Detected RPi model: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".
-  model=4
+  if ([ "$model_string" == "Zero" ]); then
+    model=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $6}')
+    echo "Detected Raspberry Pi Zero - Using model of $model".
+  elif ([ "$model_string" == "Compute" ]); then
+    model=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $7}')
+    echo "Detected Raspberry Pi Compute Module $model".
+  else
+    echo "Unknown Raspberry Pi model detected: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".
+    model=4
+  fi
 else
   echo "Detected RPi model: $model_string".
   model=$model_string

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -161,13 +161,26 @@ else
   echo "GPIO tools not available. Trying sysfs method." | write_log
 fi
 
-model=$(cat /proc/cpuinfo | grep 'Model' | cut -d ':' -f2 | xargs)
-echo "Detected RPi model: $model".
+# Detect Raspberry Pi type
+# cat /proc/cpuinfo can yield results such as:
+# Model           : Raspberry Pi 4 Model B Rev 1.1
+# Model           : Raspberry Pi 5 Model B Rev 1.0
+# Model           : Raspberry Pi Zero W Rev 1.1
+# If what is immediately after "Model" is a number, we can use that as the model number.
+# If not, we assume it is a Pi 4 or below (using GPIO chip 0).
+model_string=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
+echo "Model string: $model_string"
+if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
+  echo "Detected RPi model: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".
+  model=4
+else
+  echo "Detected RPi model: $model_string".
+  model=model_string
+fi
 
 # Determine Raspberry Pi GPIO access chip
 # chip=4 for RPi5, chip=0 for older models
-# Note this code would break on future models! (eg Rpi 6)
-if $GPIO_TOOLS_AVAILABLE && echo "$model" | grep -q "Raspberry Pi 5"; then
+if [ $GPIO_TOOLS_AVAILABLE ] && [ "$model" -gt 4 ]; then
   chip=4
 else
   chip=0

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -168,6 +168,7 @@ fi
 # Model           : Raspberry Pi Zero W Rev 1.1
 # If what is immediately after "Model" is a number, we can use that as the model number.
 # If not, we assume it is a Pi 4 or below (using GPIO chip 0).
+# This code may need updating eg if a new Zero model is released that uses GPIO chip 4.
 model_string=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
 if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
   echo "Detected RPi model: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -166,6 +166,7 @@ echo "Detected RPi model: $model".
 
 # Determine Raspberry Pi GPIO access chip
 # chip=4 for RPi5, chip=0 for older models
+# Note this code would break on future models (eg Rpi 6)
 if $GPIO_TOOLS_AVAILABLE && echo "$model" | grep -q "Raspberry Pi 5"; then
   chip=4
 else

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -174,7 +174,7 @@ if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
   model=4
 else
   echo "Detected RPi model: $model_string".
-  model=model_string
+  model=$model_string
 fi
 
 # Determine Raspberry Pi GPIO access chip

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -168,7 +168,7 @@ fi
 # Model           : Raspberry Pi Zero W Rev 1.1
 # If what is immediately after "Model" is a number, we can use that as the model number.
 # If not, we assume it is a Pi 4 or below (using GPIO chip 0).
-# This code may need updating eg if a new Zero model is released that uses GPIO chip 4.
+# !! This code may need updating eg if a new Zero model is released that uses GPIO chip 4.
 model_string=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
 if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
   echo "Detected RPi model: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".

--- a/scripts/powerblockservice
+++ b/scripts/powerblockservice
@@ -169,7 +169,6 @@ fi
 # If what is immediately after "Model" is a number, we can use that as the model number.
 # If not, we assume it is a Pi 4 or below (using GPIO chip 0).
 model_string=$(cat /proc/cpuinfo | grep 'Model' | awk '{print $5}')
-echo "Model string: $model_string"
 if ! [[ $model_string =~ $'^[0-9]+$' ]] ; then
   echo "Detected RPi model: $model_string - Forcing model to 4 (Using GPIO chip as per RPi 4 or below)".
   model=4


### PR DESCRIPTION
In the service file, when it tries to get the model, it is expecting a string like:
```
Raspberry Pi 4 Model B Rev 1.1
Raspberry Pi 5 Model B Rev 1.0
```

It then extracts the 4 or 5, and uses an "if greater than" check such that if it is greater than 4, it uses `chip=4`, else it uses `chip=0`  

On Raspberry Pi Zero ([And Compute module](https://github.com/petrockblog/PowerBlock/issues/17)), this check fails because it gets a word (`Compute` or `Zero`) instead of a number, and you can't do a greater than check on a word.  

This is further compounded by Compute Modules and Zero having slightly different format strings
According to the issue I linked, the 7th index will get the model number for a Compute Module, so this PR uses that  
For a Zero, I guess a Zero 1 would get nothing - I do not think this code would be compatible with that.  
For a Zero 2 or later, it will get the 6th index (Which would be `2`), and seeing as 2 is < 5, it would set the old GPIO.  
If a Zero model 3 is released which has the new GPIO style, this would not work.  
If a Zero model 5 is released with the old style GPIO, this would also not work.  
This is about the best I am inclined to do for now.  

**This code is untested on anything other than a Pi Zero 2 W**